### PR TITLE
Check using void data

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ The queries can be executed automatically on all endpoints they apply to using a
 java -jar target/sparql-examples-utils-*-uber.jar test --input-directory=../sparql-examples/examples -p MetaNetX --also-run-slow-tests
 ```
 
+### Using VoID data
+
+We recommend that SPARQL endpoints describe their data using VoID, in their service description.
+This can be run with.
+
+```bash
+java -jar target/sparql-examples-utils-*-uber.jar test --input-directory=../sparql-examples/examples -p UniProt --also-run-void-check
+```
+
+
 > [!NOTE]
 >
 > All CLI commands provided in this readme expects you have the [`sparql-examples`](https://github.com/sib-swiss/sparql-examples) folder cloned in the same directory alongside this `sparql-examples-utils` project folder. Feel free to change them for your own example folder and path.

--- a/src/main/java/swiss/sib/rdf/sparql/examples/SparqlInRdfToMd.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/SparqlInRdfToMd.java
@@ -2,7 +2,6 @@ package swiss.sib.rdf.sparql.examples;
 
 import static swiss.sib.rdf.sparql.examples.SparqlInRdfToRq.streamOf;
 
-import java.io.IOException;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,8 +34,6 @@ import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParser;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParserFactory;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.jsoup.Jsoup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -239,16 +236,11 @@ public class SparqlInRdfToMd {
 			Map<IRI, InUse> allInUse) {
 		while (endpoints.hasNext()) {
 			IRI endpoint = endpoints.next();
-			try {
-				var vd = ServiceDescription.retrieveVoidDataFromServiceDescription(endpoint.stringValue());
-				if (!vd.isEmpty()) {
-					allVoid.put(endpoint, vd);
-					allInUse.put(endpoint, new InUse(new HashSet<>(), new HashSet<>()));
-				}
-			} catch (IOException | UnsupportedRDFormatException | RDFParseException e) {
-				// Ignore
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
+			
+			var vd = ServiceDescription.retrieveVoIDDataFromServiceDescription(endpoint.stringValue());
+			if (!vd.isEmpty()) {
+				allVoid.put(endpoint, vd);
+				allInUse.put(endpoint, new InUse(new HashSet<>(), new HashSet<>()));
 			}
 		}
 	}

--- a/src/main/java/swiss/sib/rdf/sparql/examples/Tester.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/Tester.java
@@ -49,6 +49,9 @@ public class Tester implements Callable<Integer> {
 
 	@Option(names = { "--also-run-slow-tests" })
 	private boolean alsoRunSlowTests;
+	
+	@Option(names = { "--also-run-void-check" })
+	private boolean alsoRunVoidCheck;
 
 	@Option(names = { "--status-markdown" })
 	private File statusMarkdown;
@@ -101,6 +104,11 @@ public class Tester implements Callable<Integer> {
 			standardOptions = new ArrayList<>(standardOptions);
 			standardOptions.add("--exclude-tag");
 			standardOptions.add("SlowTest");
+		}
+		if (!alsoRunVoidCheck) {
+			standardOptions = new ArrayList<>(standardOptions);
+			standardOptions.add("--exclude-tag");
+			standardOptions.add("VoIDTest");
 		}
 		ConsoleLauncherExecutionResult execute = ConsoleLauncher.execute(System.out, System.err,
 				(String[]) standardOptions.toArray(new String[0]));

--- a/src/main/java/swiss/sib/rdf/sparql/examples/statistics/ServiceDescription.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/statistics/ServiceDescription.java
@@ -19,9 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +30,7 @@ public class ServiceDescription {
 
 	}
 
-	public static Model retrieveVoidDataFromServiceDescription(String endpoint) throws RDFParseException, UnsupportedRDFormatException, IOException, InterruptedException {
+	public static Model retrieveVoIDDataFromServiceDescription(String endpoint) {
 		Builder hcb = HttpClient.newBuilder();
 		hcb.followRedirects(Redirect.ALWAYS);
 
@@ -52,7 +50,7 @@ public class ServiceDescription {
 						var p = Rio.getParserFormatForMIMEType(ct);
 						if (p.isPresent()) {
 							RDFFormat format = p.get();
-							Model model = Rio.parse(new ByteArrayInputStream(send.body()), format,
+							Model model = Rio.parse(new ByteArrayInputStream(send.body()), endpoint, format,
 									SimpleValueFactory.getInstance().createIRI(endpoint));
 							logger.info("VoID data for : {} triples: {}", endpoint, model.size());
 							return model;
@@ -62,6 +60,10 @@ public class ServiceDescription {
 			
 		} catch (URISyntaxException e) {
 			throw new IllegalStateException(e);
+		} catch (IOException e) {
+			return new TreeModel();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
 		return new TreeModel();
 	}

--- a/src/main/java/swiss/sib/rdf/sparql/examples/statistics/ServiceDescription.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/statistics/ServiceDescription.java
@@ -1,0 +1,68 @@
+package swiss.sib.rdf.sparql.examples.statistics;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Builder;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.TreeModel;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServiceDescription {
+	private static Logger logger = LoggerFactory.getLogger(ServiceDescription.class);
+
+	private ServiceDescription() {
+
+	}
+
+	public static Model retrieveVoidDataFromServiceDescription(String endpoint) throws RDFParseException, UnsupportedRDFormatException, IOException, InterruptedException {
+		Builder hcb = HttpClient.newBuilder();
+		hcb.followRedirects(Redirect.ALWAYS);
+
+		try (HttpClient cl = hcb.build()) {
+			
+				var accept = Stream.of(RDFFormat.TURTLE, RDFFormat.RDFXML).map(RDFFormat::getDefaultMIMEType)
+						.collect(Collectors.joining(", "));
+				HttpRequest hr = HttpRequest.newBuilder(new URI(endpoint))
+						.setHeader("user-agent", "sparql-examples-utils-check-void").setHeader("accept", accept)
+						.build();
+				logger.info("Querying for VoID data at {} ", endpoint);
+				BodyHandler<byte[]> buffering = BodyHandlers.buffering(BodyHandlers.ofByteArray(), 1024);
+				HttpResponse<byte[]> send = cl.send(hr, buffering);
+				if (send.statusCode() == 200) {
+					List<String> contentTypes = send.headers().allValues("content-type");
+					for (String ct : contentTypes) {
+						var p = Rio.getParserFormatForMIMEType(ct);
+						if (p.isPresent()) {
+							RDFFormat format = p.get();
+							Model model = Rio.parse(new ByteArrayInputStream(send.body()), format,
+									SimpleValueFactory.getInstance().createIRI(endpoint));
+							logger.info("VoID data for : {} triples: {}", endpoint, model.size());
+							return model;
+						}
+					}
+				}
+			
+		} catch (URISyntaxException e) {
+			throw new IllegalStateException(e);
+		}
+		return new TreeModel();
+	}
+}

--- a/src/main/java/swiss/sib/rdf/sparql/examples/tests/CreateTestWithRDF4jMethods.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/tests/CreateTestWithRDF4jMethods.java
@@ -5,14 +5,27 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Builder;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -23,7 +36,10 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.TreeModel;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
+import org.eclipse.rdf4j.model.vocabulary.VOID;
 import org.eclipse.rdf4j.query.BooleanQuery;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.GraphQueryResult;
@@ -34,6 +50,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.Slice;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParser;
@@ -46,19 +63,19 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import swiss.sib.rdf.sparql.examples.vocabularies.SIB;
 import swiss.sib.rdf.sparql.examples.vocabularies.SchemaDotOrg;
 
 public class CreateTestWithRDF4jMethods {
-
+	private static final Logger logger = LoggerFactory.getLogger(CreateTestWithRDF4jMethods.class);
 
 	private enum QueryTypes {
-		ASK(SHACL.ASK, (rc, q) -> rc.prepareBooleanQuery(q)),
-		SELECT(SHACL.SELECT, (rc, q) -> rc.prepareTupleQuery(q)),
+		ASK(SHACL.ASK, (rc, q) -> rc.prepareBooleanQuery(q)), SELECT(SHACL.SELECT, (rc, q) -> rc.prepareTupleQuery(q)),
 		DESCRIBE(SIB.DESCRIBE, (rc, q) -> rc.prepareGraphQuery(q)),
 		CONSTRUCT(SHACL.CONSTRUCT, (rc, q) -> rc.prepareGraphQuery(q));
-
 
 		private final IRI iri;
 		private final BiFunction<RepositoryConnection, String, ? extends Query> pq;
@@ -81,10 +98,8 @@ public class CreateTestWithRDF4jMethods {
 		}
 		assertFalse(model.isEmpty());
 		QueryParser parser = new SPARQLParserFactory().getParser();
-		Stream.of(SHACL.ASK, SHACL.SELECT, SHACL.CONSTRUCT, SIB.DESCRIBE)
-			.map(s -> model.getStatements(null, s, null))
-			.map(Iterable::iterator)
-			.forEach(i -> testAllQueryStringsInModel(parser, i));
+		Stream.of(SHACL.ASK, SHACL.SELECT, SHACL.CONSTRUCT, SIB.DESCRIBE).map(s -> model.getStatements(null, s, null))
+				.map(Iterable::iterator).forEach(i -> testAllQueryStringsInModel(parser, i));
 
 	}
 
@@ -101,15 +116,13 @@ public class CreateTestWithRDF4jMethods {
 		assertFalse(model.isEmpty());
 		QueryParser parser = new SPARQLParserFactory().getParser();
 
-		return Stream.of(SHACL.ASK, SHACL.SELECT, SHACL.CONSTRUCT, SIB.DESCRIBE).map(
-				s -> model.getStatements(null, s, null))
-				.map(Iterable::iterator).map(i -> {
+		return Stream.of(SHACL.ASK, SHACL.SELECT, SHACL.CONSTRUCT, SIB.DESCRIBE)
+				.map(s -> model.getStatements(null, s, null)).map(Iterable::iterator).map(i -> {
 					return collectServiceIrisInFromOneExample(parser, i);
 				}).flatMap(Set::stream);
 	}
 
-	private static Set<String> collectServiceIrisInFromOneExample(QueryParser parser,
-			Iterator<Statement> i) {
+	private static Set<String> collectServiceIrisInFromOneExample(QueryParser parser, Iterator<Statement> i) {
 		Set<String> serviceIris = new HashSet<>();
 		while (i.hasNext()) {
 			Value obj = i.next().getObject();
@@ -135,7 +148,7 @@ public class CreateTestWithRDF4jMethods {
 
 			});
 		} catch (MalformedQueryException qe) {
-			//Ignore as tested by above;
+			// Ignore as tested by above;
 		}
 	}
 
@@ -160,9 +173,30 @@ public class CreateTestWithRDF4jMethods {
 
 	/**
 	 * Generate a test case to make sure the query runs.
+	 * 
 	 * @param p of file containing the query
 	 */
 	public static void testQueryRuns(Path p) {
+		Model model = readAllQueries(p);
+		QueryParser parser = new SPARQLParserFactory().getParser();
+		Arrays.stream(QueryTypes.values()).forEach(s -> executeAllQueryStringsInModel(parser, model, s));
+	}
+
+	/**
+	 * Generate a test case to make sure the query runs.
+	 * 
+	 * @param p of file containing the query
+	 */
+	private static final Map<String, Model> VOID_DATA_CACHE = new ConcurrentHashMap<>();
+
+	public static void testQueryMatchesVoid(Path p) {
+		Model model = readAllQueries(p);
+		QueryParser parser = new SPARQLParserFactory().getParser();
+		Arrays.stream(QueryTypes.values())
+				.forEach(s -> validateWithVoidAllQueryStringsInModel(parser, model, s, VOID_DATA_CACHE));
+	}
+
+	private static Model readAllQueries(Path p) {
 		RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE);
 		Model model = new LinkedHashModel();
 		rdfParser.setRDFHandler(new StatementCollector(model));
@@ -172,9 +206,22 @@ public class CreateTestWithRDF4jMethods {
 			fail(e);
 		}
 		assertFalse(model.isEmpty());
-		QueryParser parser = new SPARQLParserFactory().getParser();
-		Arrays.stream(QueryTypes.values())
-			.forEach(s -> executeAllQueryStringsInModel(parser, model, s));
+		return model;
+	}
+
+	private static void validateWithVoidAllQueryStringsInModel(QueryParser parser, Model m, QueryTypes qt,
+			Map<String, Model> voidDataCache) {
+		Iterator<Statement> i = m.getStatements(null, qt.iri, null).iterator();
+
+		while (i.hasNext()) {
+			Statement next = i.next();
+			Iterator<Statement> targets = m.getStatements(next.getSubject(), SchemaDotOrg.TARGET, null).iterator();
+			while (targets.hasNext()) {
+				Statement targetStatement = targets.next();
+				voidValidateQueryStringInValue(parser, next.getObject(), targetStatement.getObject(), qt,
+						voidDataCache);
+			}
+		}
 	}
 
 	private static void executeAllQueryStringsInModel(QueryParser parser, Model m, QueryTypes qt) {
@@ -182,13 +229,99 @@ public class CreateTestWithRDF4jMethods {
 		while (i.hasNext()) {
 			Statement next = i.next();
 			Iterator<Statement> targets = m.getStatements(next.getSubject(), SchemaDotOrg.TARGET, null).iterator();
-			while(targets.hasNext()) {
+			while (targets.hasNext()) {
 				Statement targetStatement = targets.next();
 				executeQueryStringInValue(parser, next.getObject(), targetStatement.getObject(), qt);
 			}
 		}
 	}
 
+	private static void voidValidateQueryStringInValue(QueryParser parser, Value obj, Value target, QueryTypes qt,
+			Map<String, Model> voidDataCache) {
+		assertNotNull(obj);
+		assertTrue(obj.isLiteral());
+		String queryStr = obj.stringValue();
+		String endpoint = target.stringValue();
+		Model voidData = voidDataCache.get(endpoint);
+		if (voidData == null) {
+			voidData = retrieveVoidDataFromServiceDescription(endpoint);
+			voidDataCache.put(endpoint, voidData);
+		}
+		if (!voidData.isEmpty()) {
+			testVoidProperties(parser, queryStr, endpoint, voidData);
+		}
+	}
+
+	private static void testVoidProperties(QueryParser parser, String queryStr, String endpoint, Model voidData) {
+		try {
+			ParsedQuery pq = parser.parseQuery(queryStr, endpoint);
+			var vis = new AbstractQueryModelVisitor<MalformedQueryException>() {
+
+				@Override
+				public void meet(Service node) throws MalformedQueryException {
+					// Do not descend into Service nodes.
+				}
+
+				@Override
+				public void meet(StatementPattern node) throws MalformedQueryException {
+					var p = node.getPredicateVar();
+					var o = node.getObjectVar();
+					if (p.isConstant() && p.getValue() instanceof IRI pi) {
+						if (RDF.TYPE.equals(pi) && o.getValue() instanceof IRI oi) {
+							assertTrue(voidData.contains(null, VOID.CLASS, oi), "Missing class: " + oi + " in "+ endpoint);
+						} else {
+							assertTrue(voidData.contains(null, VOID.PROPERTY, pi), "Missing property: " + pi + " in "+ endpoint);
+						}
+					}
+				}
+
+			};
+			pq.getTupleExpr().visit(vis);
+		} catch (MalformedQueryException qe) {
+			fail(qe.getMessage() + "\n" + queryStr, qe);
+		} catch (QueryEvaluationException qe) {
+			fail(qe.getMessage() + "\n" + queryStr, qe);
+		}
+	}
+
+	private static Model retrieveVoidDataFromServiceDescription(String endpoint) {
+		Builder hcb = HttpClient.newBuilder();
+		hcb.followRedirects(Redirect.ALWAYS);
+
+		try (HttpClient cl = hcb.build()) {
+			try {
+				var accept = Stream.of(RDFFormat.TURTLE, RDFFormat.RDFXML).map(RDFFormat::getDefaultMIMEType)
+						.collect(Collectors.joining(", "));
+				HttpRequest hr = HttpRequest.newBuilder(new URI(endpoint))
+						.setHeader("user-agent", "sparql-examples-utils-check-void").setHeader("accept", accept)
+						.build();
+				BodyHandler<byte[]> buffering = BodyHandlers.buffering(BodyHandlers.ofByteArray(), 1024);
+				HttpResponse<byte[]> send = cl.send(hr, buffering);
+				if (send.statusCode() == 200) {
+					List<String> contentTypes = send.headers().allValues("content-type");
+					for (String ct : contentTypes) {
+						var p = Rio.getParserFormatForMIMEType(ct);
+						if (p.isPresent()) {
+							RDFFormat format = p.get();
+							Model model = Rio.parse(new ByteArrayInputStream(send.body()), format,
+									SimpleValueFactory.getInstance().createIRI(endpoint));
+							logger.info("VoID data for : {} triples: {}", endpoint, model.size());
+							return model;
+						}
+					}
+				}
+			} catch (IOException | URISyntaxException e) {
+				fail(e.getMessage());
+
+			} catch (InterruptedException e) {
+				fail(e.getMessage());
+				Thread.interrupted();
+			} catch (RDFHandlerException e) {
+				// Ignore
+			}
+		}
+		return new TreeModel();
+	}
 
 	private static void executeQueryStringInValue(QueryParser parser, Value obj, Value target, QueryTypes qt) {
 		assertNotNull(obj);
@@ -198,7 +331,7 @@ public class CreateTestWithRDF4jMethods {
 		SPARQLRepository r = new SPARQLRepository(target.stringValue());
 		try {
 			r.init();
-			try (RepositoryConnection connection = r.getConnection()){
+			try (RepositoryConnection connection = r.getConnection()) {
 				queryStr = addLimitToQuery(parser, obj, qt, queryStr);
 				Query query = qt.pq.apply(connection, queryStr);
 				query.setMaxExecutionTime(45 * 60);
@@ -216,7 +349,7 @@ public class CreateTestWithRDF4jMethods {
 			bq.evaluate();
 		}
 		if (query instanceof TupleQuery tq) {
-			try (TupleQueryResult evaluate = tq.evaluate()){
+			try (TupleQueryResult evaluate = tq.evaluate()) {
 				assertTrue(evaluate.hasNext(), "Expected at least one result but got none.");
 				if (evaluate.hasNext()) {
 					evaluate.next();
@@ -224,7 +357,7 @@ public class CreateTestWithRDF4jMethods {
 			}
 		}
 		if (query instanceof GraphQuery gq) {
-			try (GraphQueryResult evaluate = gq.evaluate()){
+			try (GraphQueryResult evaluate = gq.evaluate()) {
 				assertTrue(evaluate.hasNext(), "Expected at least one result but got none.");
 				if (evaluate.hasNext()) {
 					evaluate.next();
@@ -233,15 +366,14 @@ public class CreateTestWithRDF4jMethods {
 		}
 	}
 
-	private static String addLimitToQuery(QueryParser parser, Value obj, QueryTypes qt,
-			String queryStr) {
-		//If it is not an ask we better insert a limit into the query.
+	private static String addLimitToQuery(QueryParser parser, Value obj, QueryTypes qt, String queryStr) {
+		// If it is not an ask we better insert a limit into the query.
 		if (qt != QueryTypes.ASK) {
 			HasLimit visitor = new HasLimit();
 			ParsedQuery pq = parser.parseQuery(queryStr, "https://example.org/");
 			pq.getTupleExpr().visit(visitor);
 			if (!visitor.hasLimit) {
-				//We can add the limit at the end.
+				// We can add the limit at the end.
 				queryStr = obj.stringValue() + " LIMIT 1";
 			}
 		}

--- a/src/main/java/swiss/sib/rdf/sparql/examples/tests/ValidateSparqlExamplesTest.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/tests/ValidateSparqlExamplesTest.java
@@ -43,6 +43,13 @@ public class ValidateSparqlExamplesTest {
 		return testAll(tester);
 	}
 	
+	@Tag("VoIDTest")
+	@TestFactory
+	public Stream<DynamicTest> testAllWithRDF4jVoID() throws URISyntaxException, IOException {
+		Function<Path, Executable> tester = p -> () -> CreateTestWithRDF4jMethods.testQueryMatchesVoid(p);
+		return testAll(tester);
+	}
+	
 	@TestFactory
 	public Stream<DynamicTest> testAllWithBigData() throws URISyntaxException, IOException {
 		Function<Path, Executable> tester = p -> () -> CreateTestWithBigDataMethods.testQueryValid(p);

--- a/src/main/java/swiss/sib/rdf/sparql/examples/tests/ValidateSparqlExamplesTest.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/tests/ValidateSparqlExamplesTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -46,8 +47,7 @@ public class ValidateSparqlExamplesTest {
 	@Tag("VoIDTest")
 	@TestFactory
 	public Stream<DynamicTest> testAllWithRDF4jVoID() throws URISyntaxException, IOException {
-		Function<Path, Executable> tester = p -> () -> CreateTestWithRDF4jMethods.testQueryMatchesVoid(p);
-		return testAll(tester);
+		return testAll(CreateTestWithRDF4jMethods::testQueryMatchesVoid);
 	}
 	
 	@TestFactory
@@ -103,7 +103,7 @@ public class ValidateSparqlExamplesTest {
 	}
 
 	private Stream<DynamicTest> testAll(Function<Path, Executable> tester) throws IOException {
-		return FindFiles.sparqlExamples().map(p -> createTest(tester, p.getParent(), p));
+		return FindFiles.sparqlExamples().map(p -> createTest(tester, p.getParent(), p)).filter(Objects::nonNull);
 	}
 
 	private <T> Stream<DynamicTest> testAllAsOne(Function<Path, Stream<T>> tester,
@@ -122,7 +122,11 @@ public class ValidateSparqlExamplesTest {
 	private DynamicTest createTest(Function<Path, Executable> tester, Path projectPath, Path specificExamplePath) {
 		String testName = pathToTestName(specificExamplePath);
 		Executable apply = tester.apply(specificExamplePath);
-		return DynamicTest.dynamicTest(testName, specificExamplePath.toUri(), apply);
+		if (apply != null) {
+			return DynamicTest.dynamicTest(testName, specificExamplePath.toUri(), apply);
+		} else {
+			return null;
+		}
 	}
 
 	private String pathToTestName(Path specificExamplePath) {


### PR DESCRIPTION
Query examples from endpoints that have rich VoID data can be checked to only use predicates and classes that exists in the endpoint.