### PR TITLE
enable the import-from-issue command to handle when SPARQL query provided in codeblocks

### DIFF
--- a/src/main/java/swiss/sib/rdf/sparql/examples/ImportFromGitHubIssue.java
+++ b/src/main/java/swiss/sib/rdf/sparql/examples/ImportFromGitHubIssue.java
@@ -94,7 +94,11 @@ public class ImportFromGitHubIssue implements Callable<Integer> {
         }
 
         // Extract information from the issue
-        String sparqlQuery = extractSection(content, "SPARQL query");
+        String sparqlQuery = extractSection(content, "SPARQL query").trim();
+        // Remove surrounding ```sparql ... ``` if present
+        if (sparqlQuery.startsWith("```") && sparqlQuery.endsWith("```")) {
+            sparqlQuery = sparqlQuery.substring(sparqlQuery.indexOf('\n') + 1, sparqlQuery.lastIndexOf("```")).trim();
+        }
         String description = extractSection(content, "Query description");
         String filePath = extractSection(content, "Query file path");
         List<String> targetEndpoints = extractTargetEndpoints(content);


### PR DESCRIPTION
When using `render: sparql` in the gh issue template it adds codeblocks (make the issue more readable), this changes enables the CLI to handle this @JervenBolleman 